### PR TITLE
add setValueAs in Select

### DIFF
--- a/src/app/user/properties/add/_components/basic.tsx
+++ b/src/app/user/properties/add/_components/basic.tsx
@@ -44,7 +44,7 @@ const Basic = (props: Props) => {
       />
 
       <Select
-        {...register("typeId")}
+        {...register("typeId", { setValueAs: (v: any) => v.toString() })}
         errorMessage={errors.typeId?.message}
         isInvalid={!!errors.typeId}
         label="Type"
@@ -59,7 +59,7 @@ const Basic = (props: Props) => {
         ))}
       </Select>
       <Select
-        {...register("statusId")}
+        {...register("statusId", { setValueAs: (v: any) => v.toString() })}
         errorMessage={errors.statusId?.message}
         isInvalid={!!errors.statusId}
         label="Status"
@@ -74,7 +74,7 @@ const Basic = (props: Props) => {
         ))}
       </Select>
       <Input
-        {...register("price")}
+        {...register("price", { setValueAs: (v: any) => v.toString() })}
         errorMessage={errors.price?.message}
         isInvalid={!!errors.price}
         label="Price"


### PR DESCRIPTION
### Issue Addressed

Previously, in the attribute `defaultSelectedKeys={[getValues().typeId.toString()]}`, attempting to click on the next button resulted in an error below the select input: **"Expected string, received number"**.

### Changes Made

- Updated the registry field with the following option to resolve the error:

  ```javascript
  { setValueAs: (v: any) => v.toString() }